### PR TITLE
Added language library support

### DIFF
--- a/lua/autorun/cl_chat.lua
+++ b/lua/autorun/cl_chat.lua
@@ -405,7 +405,7 @@ function chat.AddText(...)
 			eChat.chatLog:InsertColorChange( obj.r, obj.g, obj.b, obj.a )
 			table.insert( msg, Color(obj.r, obj.g, obj.b, obj.a) )
 		elseif type(obj) == "string"  then
-			eChat.chatLog:AppendText( obj )
+			eChat.chatLog:AppendText( language.GetPhrase( obj ) )
 			table.insert( msg, obj )
 		elseif type(obj) == "table"  then
 			if obj[1] == "image" then


### PR DESCRIPTION
Tweaked new chat.AddText to call language.GetPhrase before appending text. Native chat.AddText seems to do this by default, or at least similarly. Without this fix, lines may show up as #Prop_Undone instead of "Undone Prop", for example.

I'm not 100% sure this is the "proper" way to fix it, but it seemed to work in my tests.